### PR TITLE
Fix: Prevent PHP notice from corrupting CSV import JSON response

### DIFF
--- a/classes/SmileyCSVImporter.php
+++ b/classes/SmileyCSVImporter.php
@@ -171,21 +171,26 @@ class SmileyCSVImporter {
         // データ行解析
         for ($i = 1; $i < count($lines); $i++) {
             $row = str_getcsv($lines[$i]);
-            
+
             // 空行スキップ
             if (empty(array_filter($row))) {
                 continue;
             }
-            
+
             // ヘッダーとデータ結合
             $rowData = [];
-            for ($j = 0; $j < count($headers); $j++) {
-                $value = isset($row[$j]) ? trim($row[$j]) : '';
-                $rowData[$headers[$j]] = $value;
+            foreach ($row as $j => $value) {
+                // ヘッダーが存在し、かつヘッダー名が空でない場合のみ処理
+                if (isset($headers[$j]) && trim($headers[$j]) !== '') {
+                    $rowData[trim($headers[$j])] = trim($value);
+                }
             }
             
-            $rowData['_row_number'] = $i + 1;
-            $data[] = $rowData;
+            // データが空でなければ追加
+            if (!empty($rowData)) {
+                $rowData['_row_number'] = $i + 1;
+                $data[] = $rowData;
+            }
         }
         
         return $data;


### PR DESCRIPTION
The CSV import process was failing with a JSON parsing error on the frontend. This was caused by a PHP notice being printed in the API response, which invalidated the JSON format.

The notice, `Undefined offset`, was triggered in the `readCsv` method of the `SmileyCSVImporter` class. This occurred when a data row in the CSV file had more columns than the header row. The code would attempt to access an index in the header array that did not exist.

This commit fixes the issue by making the CSV parsing logic more robust:
- The loop now iterates over the data row's columns instead of the header's.
- It checks if a header exists for a given column index (`isset($headers[$j])`) before using it.
- It also ignores empty header names to handle trailing commas in the header line correctly.

This prevents the PHP notice from being generated, ensuring a valid JSON response is always sent to the frontend, thus resolving the import error.